### PR TITLE
Used wget to get rspamd apt key

### DIFF
--- a/roles/mailserver/tasks/rspamd.yml
+++ b/roles/mailserver/tasks/rspamd.yml
@@ -1,8 +1,16 @@
 ---
 # Installs and configures the Rspamd spam filtering system.
 
+- name: Get Rspamd GPG key
+  command: wget -O rspamd-gpg.key https://rspamd.com/apt-stable/gpg.key
+  args:
+    creates: rspamd-gpg.key
+  tags:
+    - dependencies
+    - skip_ansible_lint
+
 - name: Ensure repository key for Rspamd is in place
-  apt_key: url=https://rspamd.com/apt-stable/gpg.key state=present
+  apt_key: file=rspamd-gpg.key
   tags:
     - dependencies
 


### PR DESCRIPTION
This fixed the error "Failed to validate the SSL certificate for rspamd.com:443"

This is needed to be able to install sovereign on Debian Jessie or Ubuntu 16.04.